### PR TITLE
Modify text input mode

### DIFF
--- a/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
+++ b/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
@@ -448,8 +448,11 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
     $scope.$watch('menu.inputMethod', function setInputMethod(inputMethod) {
 
         // Show input methods only if selected
-        $scope.showOSK       = (inputMethod === 'osk');
-        $scope.showTextInput = (inputMethod === 'text');
+        // $scope.showOSK       = (inputMethod === 'osk');
+        // $scope.showTextInput = (inputMethod === 'text');
+
+        // テキストインプットモードを常に表示させるためにtrueで固定する
+        $scope.showTextInput = true;
 
     });
 

--- a/guacamole/src/main/frontend/src/app/textInput/directives/guacTextInput.js
+++ b/guacamole/src/main/frontend/src/app/textInput/directives/guacTextInput.js
@@ -149,8 +149,10 @@ angular.module('textInput').directive('guacTextInput', [function guacTextInput()
             }, false);
 
             target.addEventListener("compositionend", function targetComposeEnd(e) {
+                // 全角入力が確定した時点で、文字列がフォーカスした部分に送られて、テキストエリアの文字列が消去されるようにメソッドを追加
                 sendString(target.value);
                 resetTextInputTarget(TEXT_INPUT_PADDING);
+
                 composingText = false;
             }, false);
 

--- a/guacamole/src/main/frontend/src/app/textInput/directives/guacTextInput.js
+++ b/guacamole/src/main/frontend/src/app/textInput/directives/guacTextInput.js
@@ -149,6 +149,8 @@ angular.module('textInput').directive('guacTextInput', [function guacTextInput()
             }, false);
 
             target.addEventListener("compositionend", function targetComposeEnd(e) {
+                sendString(target.value);
+                resetTextInputTarget(TEXT_INPUT_PADDING);
                 composingText = false;
             }, false);
 


### PR DESCRIPTION
# What
- テキストインプットモードのテキストエリアが常に表示されるように修正
- そのテキストエリアに全角文字を入力する場合、入力確定時に文字列が送られるように修正
# Why
- テキストインプットモードでない場合、全角入力すると入力の状況がでなかったり、想定外の場所に表示されるため
- テキストエリアに全角文字を入力する場合、入力を確定しても次に半角文字を入力するまで文字列が送信されないため